### PR TITLE
feat: 가게 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.3")
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-javax-validation:1.1.3")
+
     testImplementation ('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/src/main/java/com/mojh/coffeeorder/store/controller/StoreController.java
+++ b/src/main/java/com/mojh/coffeeorder/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.mojh.coffeeorder.store.controller;
 
 import com.mojh.coffeeorder.store.dto.StoreResponseDto;
 import com.mojh.coffeeorder.store.service.StoreService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +15,12 @@ public class StoreController {
 
     public StoreController(final StoreService storeService) {
         this.storeService = storeService;
+    }
+
+    @GetMapping("/stores")
+    public ResponseEntity<List<StoreResponseDto>> retrieveStoreList() {
+        List<StoreResponseDto> stores = storeService.retrieveStoreList();
+        return ResponseEntity.ok(stores);
     }
 
 }

--- a/src/main/java/com/mojh/coffeeorder/store/domain/Store.java
+++ b/src/main/java/com/mojh/coffeeorder/store/domain/Store.java
@@ -9,14 +9,14 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import java.util.ArrayList;
 
 @Entity
 @Getter
@@ -43,12 +43,13 @@ public class Store extends BaseTimeEntity {
     @Column(nullable = false, length = 45)
     private String address;
 
-    @Column(nullable = false, length = 45)
-    private String status;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StoreStatus status;
 
     @Builder
     public Store(Owner owner, String name, Double lat, Double lng,
-                 String address, String status) {
+                 String address, StoreStatus status) {
         this.owner = owner;
         this.name = name;
         this.lat = lat;

--- a/src/main/java/com/mojh/coffeeorder/store/domain/StoreStatus.java
+++ b/src/main/java/com/mojh/coffeeorder/store/domain/StoreStatus.java
@@ -1,0 +1,23 @@
+package com.mojh.coffeeorder.store.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum StoreStatus {
+    PREPARING("준비중", "영업 준비중 또는 영업 시간 외"),
+    OPEN("영업중", "주문 접수 가능 상태"),
+    CLOSED("폐업", "영구 영업 중단");
+
+    private final String name;
+    private final String description;
+
+    StoreStatus(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public boolean canAcceptOrders() {
+        return this == OPEN;
+    }
+
+}

--- a/src/main/java/com/mojh/coffeeorder/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/mojh/coffeeorder/store/dto/StoreResponseDto.java
@@ -12,16 +12,13 @@ import lombok.NoArgsConstructor;
 public class StoreResponseDto {
     private Long id;
     private String name;
-    private String ownerName;
     private String address;
     private StoreStatus status;
 
     @Builder
-    public StoreResponseDto(Long id, String name, String ownerName,
-                            String address, StoreStatus status) {
+    public StoreResponseDto(Long id, String name, String address, StoreStatus status) {
         this.id = id;
         this.name = name;
-        this.ownerName = ownerName;
         this.address = address;
         this.status = status;
     }
@@ -30,7 +27,6 @@ public class StoreResponseDto {
         return StoreResponseDto.builder()
                                .id(store.getId())
                                .name(store.getName())
-                               .ownerName(store.getOwner().getName())
                                .address(store.getAddress())
                                .status(store.getStatus())
                                .build();

--- a/src/main/java/com/mojh/coffeeorder/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/mojh/coffeeorder/store/dto/StoreResponseDto.java
@@ -1,18 +1,38 @@
 package com.mojh.coffeeorder.store.dto;
 
+import com.mojh.coffeeorder.store.domain.Store;
+import com.mojh.coffeeorder.store.domain.StoreStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreResponseDto {
-    public int id;
-    public String name;
-    public String address;
-    public int distance;
+    private Long id;
+    private String name;
+    private String ownerName;
+    private String address;
+    private StoreStatus status;
 
-    public StoreResponseDto(int id, String name, String address, int distance) {
+    @Builder
+    public StoreResponseDto(Long id, String name, String ownerName,
+                            String address, StoreStatus status) {
         this.id = id;
         this.name = name;
+        this.ownerName = ownerName;
         this.address = address;
-        this.distance = distance;
+        this.status = status;
+    }
+
+    public static StoreResponseDto of(Store store) {
+        return StoreResponseDto.builder()
+                               .id(store.getId())
+                               .name(store.getName())
+                               .ownerName(store.getOwner().getName())
+                               .address(store.getAddress())
+                               .status(store.getStatus())
+                               .build();
     }
 }

--- a/src/main/java/com/mojh/coffeeorder/store/service/StoreService.java
+++ b/src/main/java/com/mojh/coffeeorder/store/service/StoreService.java
@@ -1,8 +1,13 @@
 package com.mojh.coffeeorder.store.service;
 
 
+import com.mojh.coffeeorder.store.dto.StoreResponseDto;
 import com.mojh.coffeeorder.store.repository.StoreRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class StoreService {
@@ -13,5 +18,10 @@ public class StoreService {
         this.storeRepository = storeRepository;
     }
 
-
+    @Transactional(readOnly = true)
+    public List<StoreResponseDto> retrieveStoreList() {
+        return storeRepository.findAll().stream()
+                              .map(StoreResponseDto::of)
+                              .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/com/mojh/coffeeorder/common/FixtureMonkeyUtil.java
+++ b/src/test/java/com/mojh/coffeeorder/common/FixtureMonkeyUtil.java
@@ -1,0 +1,19 @@
+package com.mojh.coffeeorder.common;
+
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin;
+
+public final class FixtureMonkeyUtil {
+
+    public static FixtureMonkey baseFixtureMonkey() {
+        return FixtureMonkey.builder()
+                            .defaultNotNull(true)
+                            .plugin(new JavaxValidationPlugin())
+                            .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                            .build();
+    }
+
+}
+

--- a/src/test/java/com/mojh/coffeeorder/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/mojh/coffeeorder/store/controller/StoreControllerTest.java
@@ -1,0 +1,59 @@
+package com.mojh.coffeeorder.store.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mojh.coffeeorder.store.dto.StoreResponseDto;
+import com.mojh.coffeeorder.store.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql("/db/store-dummy.sql")
+@DisplayName("가게 API 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class StoreControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    private final String BASE_URL = "/stores";
+
+    @BeforeEach
+
+    @Test
+    @DisplayName("모든 가게 목록을 단순 조회한다.")
+    void retrieveStoreList() throws Exception {
+        mockMvc.perform(get(BASE_URL))
+               .andDo(print())
+               .andExpect(status().isOk())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$", hasSize(5)));
+    }
+
+}

--- a/src/test/java/com/mojh/coffeeorder/store/service/StoreServiceTest.java
+++ b/src/test/java/com/mojh/coffeeorder/store/service/StoreServiceTest.java
@@ -1,0 +1,73 @@
+package com.mojh.coffeeorder.store.service;
+
+import com.mojh.coffeeorder.common.FixtureMonkeyUtil;
+import com.mojh.coffeeorder.owner.domain.Owner;
+import com.mojh.coffeeorder.store.domain.Store;
+import com.mojh.coffeeorder.store.dto.StoreResponseDto;
+import com.mojh.coffeeorder.store.repository.StoreRepository;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("가게 서비스 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    StoreRepository storeRepository;
+
+    @InjectMocks
+    StoreService storeService;
+
+    private final FixtureMonkey fixtureMonkey = FixtureMonkeyUtil.baseFixtureMonkey();
+
+    @Test
+    @DisplayName("모든 가게 목록을 단순 조회한다.")
+    void retrieveStoreList() {
+        // given
+        Owner owner = fixtureMonkey.giveMeOne(Owner.class);
+        List<Store> storeList = fixtureMonkey.giveMeBuilder(Store.class)
+                                             .set("owner", owner)
+                                             .sampleList(5);
+        given(storeRepository.findAll()).willReturn(storeList);
+
+        // when
+        List<StoreResponseDto> actual = storeService.retrieveStoreList();
+
+        // then
+        assertAll(
+                () -> assertThat(actual.size()).isEqualTo(storeList.size()),
+                () -> verify(storeRepository).findAll()
+        );
+    }
+
+    @Test
+    @DisplayName("조회된 가게가 하나도 없는 경우 빈 리스트를 반환한다.")
+    void retrieveStoreList_empty() {
+        // given
+        given(storeRepository.findAll()).willReturn(Collections.EMPTY_LIST);
+
+        // when
+        List<StoreResponseDto> actual = storeService.retrieveStoreList();
+
+        // then
+        assertAll(
+                () -> assertThat(actual).isEmpty(),
+                () -> verify(storeRepository).findAll()
+        );
+    }
+
+
+}

--- a/src/test/resources/db/store-dummy.sql
+++ b/src/test/resources/db/store-dummy.sql
@@ -1,0 +1,10 @@
+INSERT INTO owner (biz_num, account, password, name, created_at, updated_at)
+VALUES ('123-45-67890', 'owner1', 'password1', '사장님1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO store (owner_id, name, lat, lng, address, status, created_at, updated_at)
+VALUES
+    (1, '커피점1', 37.1, 127.1, '서울시 강남구 역삼동 1번지', 'OPEN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (1, '커피점2', 37.2, 127.2, '서울시 강남구 역삼동 2번지', 'OPEN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (1, '커피점3', 37.3, 127.3, '서울시 서초구 서초동 1번지', 'OPEN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (1, '커피점4', 37.4, 127.4, '서울시 서초구 서초동 2번지', 'PREPARING', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (1, '커피점5', 37.5, 127.5, '서울시 강남구 삼성동 1번지', 'CLOSED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);


### PR DESCRIPTION
## 설명

- resolves #7
- 실제 위치 기반 조회는 이후에 구현하고 이번 pr에서는 단순히 모든 가게 목록 조회

## 작업 내용

1. 가게 상태 enum 클래스 추가
   - 현재는 영업중, 준비중(영업 시간 외 혹은 영업 준비중), 폐업 3개만
2. 가게 목록 조회 구현
3. 테스트 코드 작성
4. Fixture Monkey 의존성 추가

## 기타 사항

- TODO: 가게 목록 조회 이후에 위치 정보 활용한 조회로 바꾸기